### PR TITLE
chore(ci,security,docs): add community health files, CI, CodeQL, Dependabot, and MIT license

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner of everything:
+* @tombelieber
+

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,21 @@
+name: Bug report
+description: File a bug
+labels: [bug]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Steps to reproduce, expected vs actual
+      placeholder: Describe clearly
+    validations: {required: true}
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs/screenshots
+      render: shell
+  - type: input
+    id: version
+    attributes:
+      label: Commit/tag
+

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,14 @@
+name: Feature request
+description: Suggest an idea
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      validations: {required: true}
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Summary
+- What does this change do?
+
+## Test Plan
+- How did you test it?
+
+## Checklist
+- [ ] I ran tests locally
+- [ ] Updated docs if needed
+- [ ] No secrets committed
+

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Supported Versions
+We support the latest commit on `main`.
+
+## Reporting a Vulnerability
+Please email security@vickyai.io (or use GitHub’s “Report a vulnerability” feature).
+We aim to respond within 72 hours.
+
+## Scope
+Report issues related to:
+- Dependency supply chain
+- Arbitrary code execution
+- Sensitive data leakage
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule: { interval: "weekly" }
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule: { interval: "weekly" }
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -r requirements.txt
+      - run: pytest -q
+

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,10 @@
+name: CodeQL
+on:
+  pull_request:
+  schedule: [{ cron: "0 3 * * 1" }]
+jobs:
+  analyze:
+    uses: github/codeql-action/.github/workflows/codeql.yml@v3
+    with:
+      languages: python
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,6 @@
+# Code of Conduct
+- Be respectful and welcoming  
+- No harassment or hate speech  
+- Assume good intent  
+- Report violations to security@vickyai.io
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+# Contributing
+
+1. Clone and create a branch from `main`.
+2. Run `pytest -q` before PR.
+3. Keep PRs small and focused.
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 Tom Tang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+


### PR DESCRIPTION
- Summary: Establish repository hygiene and automation: community files, security policy, CI tests, CodeQL, Dependabot, and MIT license. No application code changes.
- Changes:
  - Issue/PR templates and CODEOWNERS
  - SECURITY.md with reporting process and scope
  - Dependabot for pip and GitHub Actions (weekly)
  - CI workflow: install deps and run pytest
  - CodeQL workflow for Python (scheduled + PRs)
  - CONTRIBUTING.md and CODE_OF_CONDUCT.md
  - MIT LICENSE
- Why: Improves contributor experience, automates testing, strengthens security posture, and clarifies licensing.
- Risk/Impact: None to runtime; metadata and workflows only.
- Test Plan:
  - CI should install `requirements.txt` and run `pytest -q` on PR.
  - CodeQL should initialize on PR; results visible in Security tab.
- Linked Issues: Closes #<issue-id> (edit if applicable)

Checklist
- [ ] CI green (pytest)
- [ ] CodeQL completes without blocking issues
- [ ] LICENSE and templates meet project standards
- [ ] Maintainer review and approval
